### PR TITLE
fix cell re-focus

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "lerna": "2.0.0-beta.34",
-  "version": "3.1.1"
+  "version": "3.1.2"
 }

--- a/packages/react-data-grid-addons/package.json
+++ b/packages/react-data-grid-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chilangomax/react-data-grid-addons",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A set of addons for react-data-grid",
   "scripts": {
     "beforepublish": "node ../../ci/publish/replacePackageEntry react-data-grid-addons true",
@@ -18,7 +18,7 @@
   "author": "Adazzle",
   "license": "MIT",
   "dependencies": {
-    "@chilangomax/react-data-grid": "^3.1.1"
+    "@chilangomax/react-data-grid": "^3.1.2"
   },
   "devDependencies": {
     "jquery": "^2.1.1",

--- a/packages/react-data-grid-examples/package.json
+++ b/packages/react-data-grid-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chilangomax/react-data-grid-examples",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A set of examples for the grid",
   "main": "main.js",
   "scripts": {
@@ -20,16 +20,16 @@
   "author": "Adazzle",
   "license": "MIT",
   "dependencies": {
-    "immutability-helper": "^2.4.0",
-    "@chilangomax/react-data-grid": "^3.1.1",
-    "@chilangomax/react-data-grid-addons": "^3.1.1"
+    "@chilangomax/react-data-grid": "^3.1.2",
+    "@chilangomax/react-data-grid-addons": "^3.1.2",
+    "immutability-helper": "^2.4.0"
   },
   "devDependencies": {
     "bootstrap": "^3.2.0",
     "jquery": "^2.1.1",
     "lodash": "^4.13.1",
     "lodash.groupby": "^4.5.1",
-    "react-router": "^0.13.3",
-    "markdown": "^0.5.0"
+    "markdown": "^0.5.0",
+    "react-router": "^0.13.3"
   }
 }

--- a/packages/react-data-grid/package.json
+++ b/packages/react-data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chilangomax/react-data-grid",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Excel-like grid component built with React, with editors, keyboard navigation, copy & paste, and the like",
   "scripts": {
     "beforepublish": "node ../../ci/publish/replacePackageEntry react-data-grid true",

--- a/packages/react-data-grid/src/Cell.js
+++ b/packages/react-data-grid/src/Cell.js
@@ -387,6 +387,21 @@ class Cell extends React.Component {
     return document.activeElement && document.activeElement.className.indexOf('react-grid-Cell') !== -1;
   };
 
+  isAlreadyFocusedOnThisGrid = () => {
+    let gridWithFocus = document.activeElement && document.activeElement.closest('.react-grid-Container');
+
+    if (
+      // There is a grid ancestor to the currently focused element.
+      gridWithFocus &&
+      // Only assume focus if that grid has the same identifier as 
+      //  the react component ancestor to the current cell.
+      gridWithFocus.dataset.gridIdentifier === this.props.cellMetaData.gridIdentifier
+    ) {
+      return true;
+    }
+    return false;
+  };
+
   checkFocus = () => {
     if (this.isSelected() && !this.isActive()) {
       if (this.props.isScrolling && !this.props.cellMetaData.isScrollingVerticallyWithKeyboard && !this.props.cellMetaData.isScrollingHorizontallyWithKeyboard) {
@@ -396,8 +411,14 @@ class Cell extends React.Component {
       // Otherwise, only focus to the current cell if the currently active node in the document is within the data grid.
       // Meaning focus should not be stolen from elements that the grid doesnt control.
       const cellAutoFocusEnabled = this.props.cellMetaData && this.props.cellMetaData.enableCellAutoFocus;
-      let dataGridDOMNode = this.props.cellMetaData && this.props.cellMetaData.getDataGridDOMNode ? this.props.cellMetaData.getDataGridDOMNode() : null;
-      if (this.isFocusedOnCell() || (cellAutoFocusEnabled && this.isFocusedOnBody()) || (dataGridDOMNode && dataGridDOMNode.contains(document.activeElement))) {
+      
+      // I am replacing both isFocusedOnCell and dataGridDOMNode.contains with isAlreadyFocusedOnThisGrid, because it 
+      //  better encapsulates the semantics and essentially does a lookup in the reverse order from the latter, for which 
+      //  the ref is often null - rendering it useless.
+      if (
+        cellAutoFocusEnabled && this.isFocusedOnBody() ||
+        this.isAlreadyFocusedOnThisGrid()
+      ) {
         let cellDOMNode = this.node;
         if (cellDOMNode) {
           cellDOMNode.focus();

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -165,6 +165,8 @@ class ReactDataGrid extends React.Component {
       initialState.sortDirection = this.props.sortDirection;
     }
 
+
+    this.gridIdentifier = `G-${Math.floor(Math.random() * 1000000)}}`;
     this.state = initialState;
   }
 
@@ -1185,6 +1187,7 @@ class ReactDataGrid extends React.Component {
 
   render() {
     let cellMetaData = {
+      gridIdentifier: this.gridIdentifier,
       rowKey: this.props.rowKey,
       selected: this.state.selected,
       dragged: this.state.dragged,
@@ -1228,8 +1231,11 @@ class ReactDataGrid extends React.Component {
       gridWidth = '100%';
     }
     return (
-      <div className="react-grid-Container" style={{width: containerWidth}}
-        ref={(node) => { this.grid = node; }}>
+      <div className="react-grid-Container"
+        style={{width: containerWidth}}
+        ref={(node) => { this.grid = node; }}
+        data-grid-identifier={this.gridIdentifier}
+      >
         {toolbar}
         <div className="react-grid-Main">
           <BaseGrid
@@ -1261,10 +1267,11 @@ class ReactDataGrid extends React.Component {
             rowScrollTimeout={this.props.rowScrollTimeout}
             scrollToRowIndex={this.props.scrollToRowIndex}
             contextMenu={this.props.contextMenu}
-            overScan={this.props.overScan} />
-          </div>
+            overScan={this.props.overScan}
+          />
         </div>
-      );
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
The old way we determined if a cell should take focus was simply to look at:
  1. Is it at the current selected idx in its grid?
  2. Is the activeElement also a cell?

There are also some secondary considerations if this fails (although these are largely unimportant).

The problem is with [2], because we have multiple grids in one page - we don't want every newly mounted grid to take focus and place it at its `0, 0` cell.

I have added unique identifiers per grid, and before taking focus we check if the activeElement belongs to the same grid as the cell.